### PR TITLE
日時を文字列に変換するヘルパー関数を作成

### DIFF
--- a/api/app/Http/Controllers/Admin/ProfilesController.php
+++ b/api/app/Http/Controllers/Admin/ProfilesController.php
@@ -110,7 +110,7 @@ class ProfilesController extends Controller
             'name_kana' => ['string', 'max:255', 'nullable'],
             'grade' => ['int'],
             'part' => ['string', Rule::in(Part::SOPRANO, Part::ALTO, Part::TENOR, Part::BASS)],
-            'birthday' => ['string', 'date'],
+            'birthday' => ['string', 'date', 'nullable'],
         ]);
         if ($validator->fails()) {
             return response()->json([

--- a/client/composables/useAdminUsers.ts
+++ b/client/composables/useAdminUsers.ts
@@ -91,9 +91,10 @@ export const useAdminUsers = () => {
         user.value.profile.partFormatted = "";
         break;
     }
-    user.value.profile.birthdayFormatted = new Date(
+    const { dateToString } = useDatetimeFormatter();
+    user.value.profile.birthdayFormatted = dateToString(
       user.value.profile.birthday,
-    ).toLocaleDateString();
+    );
   }
 
   const updateUser = async (id: number, body) => {

--- a/client/utils/useDatetimeFormatter.ts
+++ b/client/utils/useDatetimeFormatter.ts
@@ -1,0 +1,24 @@
+export const useDatetimeFormatter = () => {
+  const datetimeFormatter = new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+  const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+  });
+
+  function datetimeToString(datetime) {
+    if (datetime === undefined || datetime === null || datetime === "")
+      return null;
+    return datetimeFormatter.format(new Date(datetime));
+  }
+
+  function dateToString(date) {
+    if (date === undefined || date === null || date === "") return null;
+    return dateFormatter.format(new Date(date));
+  }
+  return {
+    datetimeToString,
+    dateToString,
+  };
+};


### PR DESCRIPTION
## 変更の概要

<!-- 対応するIssueのリンクを貼ってください -->
<!-- URLを貼るとIssue番号だけ表示されます -->
<!-- 対応するIssueをCloseする場合はIssue番号の前に `Closes` を追加してください -->
* Closes #90 
* Closes #91 

## 変更の理由

<!-- どうしてこの変更をするのか、理由を詳細に述べてください -->
<!-- 詳しい理由がIssueに書かれている場合はIssueを参照するよう記述してください -->
* 日時を文字列に変換するときに、月と日がzero padding されていなかった
* 上記Issueを参照

## やったこと

<!-- 今回のPRで対応した変更箇所を記述してください -->
* `datetimeFormatter` を作成し、`datetime` が `null` でも日時を処理できるようにした
* `2000/1/1` と変換されていたものを `2000/01/01` と変換されるようにした

## 影響範囲

<!-- 影響するユーザー、システムの範囲を記述してください -->
<!-- 全ユーザーに影響するのか、管理者のみに影響するのか -->
* 全ユーザー対象
